### PR TITLE
Betriebsrat Wahlberechtigung von 18 Jahren auf 16 Jahre gesenkt

### DIFF
--- a/content/de/AbschlussprüfungTeil2Wirtschaft/Betriebsrat.md
+++ b/content/de/AbschlussprüfungTeil2Wirtschaft/Betriebsrat.md
@@ -11,7 +11,7 @@ Der Betriebsrat arbeitet zusammen mit der Geschäftsführung am Wohl der Mitarbe
 
 - Möglich ab mindestens 5 Arbeitnehmern
 - Amtszeit ist 4 Jahre
-- Alle Mitarbeiter **über 18** sind Wahlberechtigt
+- Alle Mitarbeiter **über 16** sind Wahlberechtigt
 - Wählbar sind alle Mitarbeiter **über 18** die mindesten **6 Monate** dem Betrieb angehörig sind
 - Muss über die Umstände des Betriebes informiert werden (Insbesondere bei Personalbelangen)
 


### PR DESCRIPTION
Mit dem Be­triebsräte­mo­der­ni­sie­rungs­ge­setz vom 14.06.2021 wurde das aktive Wahlrecht von 18 Jahren auf 16 Jahre gesenkt.