### PR TITLE
Transparente bilder auch im Dark-Mode lesbar machen

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,0 +1,5 @@
+@media (prefers-color-scheme: dark) {
+  img {
+    background-color: white;
+  }
+}


### PR DESCRIPTION
Ich bin über dieses Bild gestolpert:
https://fachinformatikerpruefungsvorbereitung.de/abschlusspr%C3%BCfungteil2ae/ga2/sql/#abfragen-%C3%BCber-mehrere-tabellen-joins
Der Text lässt sich nicht im Dark-Mode lesen.
Dieses kleine custom-css löst das (ich bin kein CSS-Profi. Wenn es einen besseren Weg gibt das zu machen, her damit)