### PR TITLE
fix: command was invalid

### DIFF
--- a/content/de/AbschlussprüfungTeil1/Systemintegration/Storage/index.md
+++ b/content/de/AbschlussprüfungTeil1/Systemintegration/Storage/index.md
@@ -25,7 +25,7 @@ Ein **Dateisystem** befindet sich auf dem Blockgerät, um Daten zu speichern. Si
 
 ### Beispiel Dateisystem
 
-Wie `mount/dev/sda1/mnt/somepath`
+Wie `mount /dev/sda1 /mnt/somepath`
 
 ## SAN - Storage Area Network
 


### PR DESCRIPTION
Ein falscher command wurde dort angezeigt. mount/dev/sda1/mnt/somepath ergibt wenig sinn und erfuellt die funktion des mount commands nicht. 

Man page fuer den command:
https://man7.org/linux/man-pages/man8/mount.8.html